### PR TITLE
更新说明加载的ncnn库为动态库版本。

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ https://github.com/nihui/ncnn-android-squeezenet/releases
 ### step1
 https://github.com/Tencent/ncnn/releases
 
-* Download ncnn-YYYYMMDD-android-vulkan.zip or build ncnn for android yourself
-* Extract ncnn-YYYYMMDD-android-vulkan.zip into **app/src/main/jni** and change the **ncnn_DIR** path to yours in **app/src/main/jni/CMakeLists.txt**
+* Download ncnn-YYYYMMDD-android-vulkan-shared.zip or build ncnn for android yourself
+* Extract ncnn-YYYYMMDD-android-vulkan-shared.zip into **app/src/main/jni** and change the **ncnn_DIR** path to yours in **app/src/main/jni/CMakeLists.txt**
 
 ### step2
 * Open this project with Android Studio, build it and enjoy!


### PR DESCRIPTION
原因：加载静态库编译会报错。